### PR TITLE
Fix dropdown options getting cut off on smaller displays.

### DIFF
--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -28,6 +28,8 @@ const Menu = styled.ul`
   padding: 0;
   list-style: none;
   background-color: ${props => props.theme.highlight};
+  max-height: 90vh;
+  overflow: auto;
 
   > li {
     padding: .15em .5em;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/30431861/112796499-a441b680-909c-11eb-92fa-adc95b4ac2e2.png)

Now its scrollable:
![image](https://user-images.githubusercontent.com/30431861/112796438-8d9b5f80-909c-11eb-95c3-645151ee3afa.png)
