### PR TITLE
Ensure that dropdown is not cut off on even smaller displays.

### DIFF
--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -28,7 +28,7 @@ const Menu = styled.ul`
   padding: 0;
   list-style: none;
   background-color: ${props => props.theme.highlight};
-  max-height: 90vh;
+  max-height: calc(100vh - 2em);
   overflow: auto;
 
   > li {


### PR DESCRIPTION
Was using it on my phone and notice the last 1-2 options was still getting cut off whoops! this PR fixes it.

Before:
![image](https://user-images.githubusercontent.com/30431861/112928927-102e2880-914a-11eb-811a-bb28cb977b60.png)

After some max-height adjustment:
![image](https://user-images.githubusercontent.com/30431861/112928949-191efa00-914a-11eb-8181-d7f8051849c4.png)
