### PR TITLE
Add Lua Highlighting

### DIFF
--- a/src/util/highlighting.ts
+++ b/src/util/highlighting.ts
@@ -15,6 +15,7 @@ export const languages = {
     'rust',
     'sql',
     'go',
+    'lua',
   ],
   web: ['html', 'css', 'scss', 'php', 'graphql'],
   misc: ['dockerfile', 'markdown', 'proto'],


### PR DESCRIPTION
Just adds Lua to the code highlighters in `utils/highlighting.ts`. Useful for sharing NeoVim configuration files