### PR TITLE
feat: add C and Swift as valid languages

### DIFF
--- a/src/util/highlighting.ts
+++ b/src/util/highlighting.ts
@@ -15,6 +15,8 @@ export const languages = {
     'rust',
     'sql',
     'go',
+    'swift',
+    'c'
   ],
   web: ['html', 'css', 'scss', 'php', 'graphql'],
   misc: ['dockerfile', 'markdown', 'proto'],


### PR DESCRIPTION
adds C & Swift as languages

**C example:**
```c
#include <stdio.h>
int main() {
   printf("Hello, World!");
   return 0;
}
```
**Swift example:**
```swift
import Foundation
print("Hello, World!")
```